### PR TITLE
Fixes an errant view name causing the api/example/id page to not be a…

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.9 (gender_analysis_web)" project-jdk-type="Python SDK" />
+  <component name="WebPackConfiguration">
+    <option name="mode" value="DISABLED" />
+  </component>
 </project>

--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -27,7 +27,7 @@ from django.shortcuts import render
 
 
 @api_view(['GET'])
-def example(request, example_id):
+def get_example(request, example_id):
     """
     API example endpoint.
     """

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -25,7 +25,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
 
     # API endpoints
-    path('api/example/<int:example_id>', views.example),
+    path('api/example/<int:example_id>', views.get_example),
 
     # View paths
     path('', views.index, name='index'),


### PR DESCRIPTION
…ccessible

# Overview
Does what it says on the tin. In setting up the project, I gave a few `view` routes the same name, causing the page at `api/example/<int>` to be in accessible. This resolves the issue by giving all example routes distinct names.