### PR TITLE
Fixed Another Bug with Frontend Form

### DIFF
--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -99,7 +99,7 @@ def add_document(request):
     fields = {
         'title': attributes['title'],
         'author': attributes['author'],
-        'year': attributes['year'],
+        'year': attributes['year'] if attributes['year'] != '' else None,
         'text': attributes['text']
     }
     new_text_obj = Document.objects.create_document(**fields)

--- a/frontend/components/Documents.js
+++ b/frontend/components/Documents.js
@@ -59,6 +59,7 @@ const Documents = () => {
     const handleSubmit = (event) => {
         event.preventDefault();
         setAddingDoc(true);
+        handleCloseModal();
         const csrftoken = getCookie("csrftoken");
         const requestOptions = {
             method: "POST",
@@ -156,7 +157,7 @@ const Documents = () => {
                             <button className="btn btn-secondary"
                                 onClick={handleCloseModal}>Close</button>
                             <button className="btn btn-primary"
-                                type="submit" onClick={handleCloseModal}>Add</button>
+                                type="submit">Add</button>
                         </Modal.Footer>
                     </form>
                 </Modal>

--- a/frontend/components/Documents.js
+++ b/frontend/components/Documents.js
@@ -141,6 +141,8 @@ const Documents = () => {
                                     <input type="number" className="form-control"
                                         id="year" value={newDocData.year}
                                         max="9999"
+                                        onKeyDown={ e => ( e.key === "e" || e.key === "." ) &&
+                                            e.preventDefault() }
                                         onChange={handleYearInputChange}/>
                                 </div>
                             </div>


### PR DESCRIPTION
This PR fixes 3 bugs with the add document form:
- `view.py` threw an error when given an empty string
- `handleCloseModal` prevented the form validation to go through, allowing user to have an empty `text` attribute
- users could input `e` and `.` into the `year` field