### PR TITLE
Simplify Documents Page

### DIFF
--- a/backend/app/serializers.py
+++ b/backend/app/serializers.py
@@ -18,6 +18,7 @@ class DocumentSerializer(serializers.ModelSerializer):
         model = Document
         fields = ['id', 'author', 'title', 'year', 'text', 'word_count']
 
+
 class SimpleDocumentSerializer(serializers.ModelSerializer):
     """
     Serializes a Document object (does not include the text itself)

--- a/backend/app/serializers.py
+++ b/backend/app/serializers.py
@@ -17,3 +17,11 @@ class DocumentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Document
         fields = ['id', 'author', 'title', 'year', 'text', 'word_count']
+
+class SimpleDocumentSerializer(serializers.ModelSerializer):
+    """
+    Serializes a Document object (does not include the text itself)
+    """
+    class Meta:
+        model = Document
+        fields = ['id', 'author', 'title', 'year', 'word_count']

--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -46,6 +46,7 @@ def get_example(request, example_id):
     }
     return Response(data)
 
+
 def index(request):
     """
     Home page
@@ -91,6 +92,7 @@ def example_id(request, example_id):
 
     return render(request, 'index.html', context)
 
+
 @api_view(['POST'])
 def add_document(request):
     """
@@ -107,11 +109,13 @@ def add_document(request):
     serializer = DocumentSerializer(new_text_obj)
     return Response(serializer.data)
 
+
 @api_view(['GET'])
 def all_documents(request):
     doc_objs = Document.objects.all()
     serializer = SimpleDocumentSerializer(doc_objs, many=True)
     return Response(serializer.data)
+
 
 def documents(request):
     """

--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -29,7 +29,8 @@ from .models import (
     Document
 )
 from .serializers import (
-    DocumentSerializer
+    DocumentSerializer,
+    SimpleDocumentSerializer
 )
 
 
@@ -109,7 +110,7 @@ def add_document(request):
 @api_view(['GET'])
 def all_documents(request):
     doc_objs = Document.objects.all()
-    serializer = DocumentSerializer(doc_objs, many=True)
+    serializer = SimpleDocumentSerializer(doc_objs, many=True)
     return Response(serializer.data)
 
 def documents(request):

--- a/frontend/components/Documents.js
+++ b/frontend/components/Documents.js
@@ -69,7 +69,7 @@ const Documents = () => {
             },
             body: JSON.stringify({
                 title: newDocData.title,
-                year: typeof newDocData.year === "string" ? null : newDocData.year,
+                year: newDocData.year,
                 author: newDocData.author,
                 text: newDocData.text
             })
@@ -90,28 +90,47 @@ const Documents = () => {
 
     const docInfo = (doc, i) => {
         return (
-            <ul> Document {i}
-                {Object.keys(doc).map((attribute, i) => (
-                    <li key={i}>{attribute}: {doc[attribute]}</li>
-                ))}
-            </ul>
+            <div className="card" key={i}>
+                <div className="card-body">
+
+                    <p>
+                        <b>{doc.title}</b>
+                        <br/>
+                        {doc.author}
+                        <br/>
+                        Year Published: {doc.year ? doc.year : "Unknown"}
+                        <br/>
+                        Word Count: {doc.word_count}
+                    </p>
+
+                </div>
+            </div>
         );
     };
 
     const docList = () => {
         return (
-            <ul>
-                {docData.map((doc, i) => (
-                    <li key={i}> {docInfo(doc, i)} </li>
-                ))}
-            </ul>
+            <div className="container-fluid">
+                <div className="row">
+                    {docData.map((doc, i) => (
+                        <div className="col-6 mb-3" key={i}>
+                            {docInfo(doc, i)}
+                        </div>
+                    ))}
+                </div>
+            </div>
+            // <ul>
+            //     {docData.map((doc, i) => (
+            //         <li key={i}> {docInfo(doc, i)} </li>
+            //     ))}
+            // </ul>
         );
     };
 
     const addDocModal = () => {
         return (
             <>
-                <button className="btn btn-primary"
+                <button className="btn btn-primary mb-3"
                     onClick={handleShowModal}>Add Document</button>
                 <Modal show={showModal} onHide={handleCloseModal}>
                     <Modal.Header closeButton>Add Document</Modal.Header>
@@ -169,7 +188,7 @@ const Documents = () => {
 
     return (
         <div>
-            <h1>This is the Documents page.</h1>
+            <h1>Documents</h1>
             <p>
                 This page displays all the documents stored in backend.
             </p>
@@ -185,7 +204,6 @@ const Documents = () => {
                 loading
                     ? <p>Currently Loading Documents...</p>
                     : <div>
-                        Documents:
                         {docList()}
                     </div>
             }

--- a/frontend/components/Documents.js
+++ b/frontend/components/Documents.js
@@ -88,14 +88,12 @@ const Documents = () => {
             });
     };
 
-    const docInfo = (doc, i) => {
+    const docInfo = (doc) => {
         return (
-            <div className="card" key={i}>
+            <div className="card">
                 <div className="card-body">
-
+                    <h6 className="mb-0">{doc.title}</h6>
                     <p>
-                        <b>{doc.title}</b>
-                        <br/>
                         {doc.author}
                         <br/>
                         Year Published: {doc.year ? doc.year : "Unknown"}

--- a/frontend/components/Documents.js
+++ b/frontend/components/Documents.js
@@ -69,7 +69,7 @@ const Documents = () => {
             },
             body: JSON.stringify({
                 title: newDocData.title,
-                year: newDocData.year,
+                year: typeof newDocData.year === "string" ? null : newDocData.year,
                 author: newDocData.author,
                 text: newDocData.text
             })

--- a/frontend/components/Documents.js
+++ b/frontend/components/Documents.js
@@ -119,11 +119,6 @@ const Documents = () => {
                     ))}
                 </div>
             </div>
-            // <ul>
-            //     {docData.map((doc, i) => (
-            //         <li key={i}> {docInfo(doc, i)} </li>
-            //     ))}
-            // </ul>
         );
     };
 


### PR DESCRIPTION
This PR:
- created a new serializer that excludes the `text` field
- update the `all_documents` API to use the simplified serializer
- updated the documents page to display each document as a card

<img width="1440" alt="Screen Shot 2021-06-29 at 6 11 01 PM" src="https://user-images.githubusercontent.com/32581282/123874251-da920a80-d905-11eb-82b7-90e6350569b7.png">
