### PR TITLE
Added initial common variables

### DIFF
--- a/backend/app/common.py
+++ b/backend/app/common.py
@@ -2,15 +2,7 @@
 Miscellaneous utility functions and variables useful throughout the system
 """
 from textwrap import dedent
-from app.models import Gender
 from nltk.corpus import stopwords
-
-FEMALE = Gender.objects.all().filter(label="Female")
-MALE = Gender.objects.all().filter(label="Male")
-NONBINARY = Gender.objects.all().filter(label="Neo")
-
-BINARY_GROUP = [FEMALE, MALE]
-TRINARY_GROUP = [FEMALE, MALE, NONBINARY]
 
 SWORDS_ENG = stopwords.words('english')
 

--- a/backend/app/common.py
+++ b/backend/app/common.py
@@ -1,8 +1,55 @@
 """
-Miscellaneous utility functions useful throughout the system
+Miscellaneous utility functions and variables useful throughout the system
 """
 from textwrap import dedent
+from app.models import Gender
+from nltk.corpus import stopwords
 
+FEMALE = Gender.objects.all().filter(label="Female")
+MALE = Gender.objects.all().filter(label="Male")
+NONBINARY = Gender.objects.all().filter(label="Neo")
+
+BINARY_GROUP = [FEMALE, MALE]
+TRINARY_GROUP = [FEMALE, MALE, NONBINARY]
+
+SWORDS_ENG = stopwords.words('english')
+
+NLTK_TAGS = {
+    'CC': 'conjunction, coordinating',
+    'CD': 'numeral, cardinal',
+    'DT': 'determiner',
+    'EX': 'existential there',
+    'IN': 'preposition or conjunction, subordinating',
+    'JJ': 'adjective or numeral, ordinal',
+    'JJR': 'adjective, comparative',
+    'JJS': 'adjective, superlative',
+    'LS': 'list item marker',
+    'MD': 'modal auxiliary',
+    'NN': 'noun, common, singular or mass',
+    'NNP': 'noun, proper, singular',
+    'NNS': 'noun, common, plural',
+    'PDT': 'pre-determiner',
+    'POS': 'genitive marker',
+    'PRP': 'pronoun, personal',
+    'PRP$': 'pronoun, possessive',
+    'RB': 'adverb',
+    'RBR': 'adverb, comparative',
+    'RBS': 'adverb, superlative',
+    'RP': 'particle',
+    'TO': '"to" as preposition or infinitive marker',
+    'UH': 'interjection',
+    'VB': 'verb, base form',
+    'VBD': 'verb, past tense',
+    'VBG': 'verb, present participle or gerund',
+    'VBN': 'verb, past participle',
+    'VBP': 'verb, present tense, not 3rd person singular',
+    'VBZ': 'verb, present tense, 3rd person singular',
+    'WDT': 'WH-determiner',
+    'WP': 'WH-pronoun',
+    'WRB': 'Wh-adverb',
+}
+
+NLTK_TAGS_ADJECTIVES = ["JJ", "JJR", "JJS"]
 
 def print_header(header_str):
     """

--- a/backend/app/common.py
+++ b/backend/app/common.py
@@ -2,17 +2,7 @@
 Miscellaneous utility functions and variables useful throughout the system
 """
 from textwrap import dedent
-from app.models import Gender
 from nltk.corpus import stopwords
-
-def get_gender_female():
-    return Gender.objects.all().filter(label="Female")
-
-def get_gender_male():
-    return Gender.objects.all().filter(label="Male")
-
-def get_gender_non_binary():
-    return Gender.objects.all().filter(label="Neo")
 
 SWORDS_ENG = stopwords.words('english')
 

--- a/backend/app/common.py
+++ b/backend/app/common.py
@@ -2,7 +2,17 @@
 Miscellaneous utility functions and variables useful throughout the system
 """
 from textwrap import dedent
+from app.models import Gender
 from nltk.corpus import stopwords
+
+def get_gender_female():
+    return Gender.objects.all().filter(label="Female")
+
+def get_gender_male():
+    return Gender.objects.all().filter(label="Male")
+
+def get_gender_non_binary():
+    return Gender.objects.all().filter(label="Neo")
 
 SWORDS_ENG = stopwords.words('english')
 


### PR DESCRIPTION
This PR adds initial common variables in `common.py` that are used for analysis purposes. 

More specifically the following variables are added:

- `FEMALE`: a `Gender` instance for female pulled from the database of initial values
- `MALE`: a `Gender` instance for male pulled from the database of initial values
- `NONBINARY`: a `Gender` instance for nonbinary pulled from the database of initial values
- `BINARY_GROUP`: a Python list of female and male `Gender` instances
- `TRINARY_GROUP`: a Python list of female, male, and nonbinary `Gender` instances
- `SWORDS_ENG`: a Python list of English stopwords from the nltk package
- `NLTK_TAGS`: a Python dictionary mapping parts of speech tags to their definitions
- `NLTK_TAGS_ADJECTIVES`: a Python list of adjective tags ('JJ', 'JJR', 'JJS')