### PR TITLE
Create API Endpoint for Gender Model

### DIFF
--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -26,11 +26,13 @@ from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from django.shortcuts import render
 from .models import (
-    Document
+    Document,
+    Gender
 )
 from .serializers import (
     DocumentSerializer,
-    SimpleDocumentSerializer
+    SimpleDocumentSerializer,
+    GenderSerializer
 )
 
 
@@ -155,3 +157,10 @@ def single_document(request, doc_id):
     }
 
     return render(request, 'index.html', context)
+
+
+@api_view(['GET'])
+def all_genders(request):
+    gender_objs = Gender.objects.all()
+    serializer = GenderSerializer(gender_objs, many=True)
+    return Response(serializer.data)

--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -114,6 +114,9 @@ def add_document(request):
 
 @api_view(['GET'])
 def all_documents(request):
+    """
+    API Endpoint to get all the documents
+    """
     doc_objs = Document.objects.all()
     serializer = SimpleDocumentSerializer(doc_objs, many=True)
     return Response(serializer.data)
@@ -121,6 +124,9 @@ def all_documents(request):
 
 @api_view(['GET'])
 def get_document(request, doc_id):
+    """
+    API Endpoint to get a document based on the ID
+    """
     doc_obj = Document.objects.get(id=doc_id)
     serializer = DocumentSerializer(doc_obj)
     return Response(serializer.data)
@@ -161,6 +167,9 @@ def single_document(request, doc_id):
 
 @api_view(['GET'])
 def all_genders(request):
+    """
+    API Endpoint to get all gender instances.
+    """
     gender_objs = Gender.objects.all()
     serializer = GenderSerializer(gender_objs, many=True)
     return Response(serializer.data)

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -29,6 +29,7 @@ urlpatterns = [
     path('api/all_documents', views.all_documents),
     path('api/add_document', views.add_document),
     path('api/document/<int:doc_id>', views.get_document),
+    path('api/all_genders', views.all_genders),
 
     # View paths
     path('', views.index, name='index'),


### PR DESCRIPTION
This PR creates an API endpoint to retrieve all the genders in the `gender` model and adds missing docstrings in other API endpoints. The `all_genders` API endpoint can be used by analysis modules to allow users to decide which genders to perform the analysis on.