### PR TITLE
Bug in Document Page

### DIFF
--- a/frontend/components/SingleDocument.js
+++ b/frontend/components/SingleDocument.js
@@ -28,7 +28,7 @@ const SingleDocument = ({id}) => {
                     <p>
                         Author: {docData.author}
                         <br/>
-                        Year Published {docData.year ? docData : "Unknown"}
+                        Year Published {docData.year ? docData.year : "Unknown"}
                         <br/>
                         Word Count: {docData.word_count.toLocaleString()}
                     </p>


### PR DESCRIPTION
This PR fixes a bug on the `document` page where the year published breaks if the `year` field is not empty.