### PR TITLE
Add Delete Functionality to Corpora Page

### DIFF
--- a/frontend/components/Corpora.js
+++ b/frontend/components/Corpora.js
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from "react";
 import STYLES from "./Corpora.module.scss";
 import {getCookie} from "../common";
-import {Modal} from "react-bootstrap";
+import {CloseButton, Modal, OverlayTrigger, Tooltip} from "react-bootstrap";
 
 const Corpora = () => {
     const [corporaData, setCorporaData] = useState([]);
@@ -107,6 +107,26 @@ const Corpora = () => {
         );
     };
 
+    const deleteCorpus = (id) => {
+        const confirmDelete = confirm("Are you sure you want to delete the corpus?");
+        if (confirmDelete) {
+            const requestOptions = {
+                method: "DELETE",
+                headers: {
+                    "Content-Type": "application/json"
+                },
+                body: JSON.stringify({
+                    id: id
+                })
+            };
+            fetch("/api/delete_corpus", requestOptions)
+                .then(() => {
+                    setCorporaData(prevCorporaData =>
+                        prevCorporaData.filter(corpus => corpus.id !== id));
+                });
+        }
+    };
+
     const corporaList = () => {
         return (
             <>
@@ -114,6 +134,12 @@ const Corpora = () => {
                     <div className="col-6 mb-3" key={i}>
                         <div className="card">
                             <div className="card-body">
+                                <OverlayTrigger
+                                    placement="right"
+                                    overlay={<Tooltip>Delete Corpus</Tooltip>}>
+                                    <CloseButton
+                                        onClick={() => deleteCorpus(corpus.id)}></CloseButton>
+                                </OverlayTrigger>
                                 <h2 className={STYLES.title}>{corpus.title}</h2>
                                 <p>{corpus.description}</p>
                             </div>


### PR DESCRIPTION
This PR allows users to delete a `Corpus` instance from the `Corpora` page.

<img width="1440" alt="Screen Shot 2021-07-19 at 5 42 06 PM" src="https://user-images.githubusercontent.com/32581282/126231585-ce160ba7-f9bf-492d-b1e5-144e581c0de6.png">
<img width="1440" alt="Screen Shot 2021-07-19 at 5 41 56 PM" src="https://user-images.githubusercontent.com/32581282/126231589-2b16800c-eb46-42c5-aa44-b051b15bf2c4.png">
