### PR TITLE
Add padding to word windows

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -5,6 +5,7 @@ import nltk
 import string
 import re
 from collections import Counter
+from itertools import chain
 from more_itertools import windowed
 from django.db import models
 from .fields import LowercaseCharField
@@ -415,10 +416,12 @@ class Document(models.Model):
 
         counter = Counter()
 
-        for text_window in windowed(self.tokenized_text, 2 * window_size + 1):
+        padding = [None] * window_size
+
+        for text_window in windowed(chain(padding, self.tokenized_text, padding), 2 * window_size + 1):
             if text_window[window_size] in search_terms:
                 for surrounding_word in text_window:
-                    if surrounding_word not in search_terms:
+                    if surrounding_word is not None and surrounding_word not in search_terms:
                         counter[surrounding_word] += 1
 
         return counter

--- a/backend/app/tests.py
+++ b/backend/app/tests.py
@@ -156,10 +156,16 @@ class DocumentTestCase(TestCase):
     def test_get_word_windows(self):
         doc = Document.objects.get(title='doc6')
         windows_1 = Counter(
-            {'he': 1, 'lit': 1, 'cigarette': 1, 'and': 1, 'then': 1, 'began': 1, 'speech': 1, 'which': 1})
+            {'he': 1, 'lit': 1, 'cigarette': 1, 'and': 1, 'then': 1, 'began': 1, 'speech': 1, 'which': 1}
+        )
         windows_2 = Counter({'her': 2, 'of': 1, 'and': 1, 'handed': 1, 'proposal': 1, 'drowned': 1, 'the': 1})
+        windows_3 = Counter({'tears': 1, 'drowned': 1, 'the': 1})
+        windows_4 = Counter({'she': 1, 'a': 2, 'lighter': 1, 'cigarette': 1, 'and': 1, 'deep': 1})
+
         self.assertEqual(doc.get_word_windows('his', window_size=2), windows_1)
         self.assertEqual(doc.get_word_windows(['purse', 'tears']), windows_2)
+        self.assertEqual(doc.get_word_windows('ring', window_size=3), windows_3)
+        self.assertEqual(doc.get_word_windows('took'), windows_4)
 
     def test_get_word_freq(self):
         doc = Document.objects.get(title='doc7')


### PR DESCRIPTION
This PR proposes to add padding to any sequence with which a function calls the `more_itertools.windowed` function. This ensures that the first and last `window_size` words or tokens are included in any searches that use the `windowed` function. The padding makes use of the [`itertools.chain`](https://docs.python.org/3/library/itertools.html#itertools.chain) method as suggested in the [`more_itertools` documentation](https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.windowed).

At this stage, the only use of the `windowed` function is in the `Document.get_word_windows` method. This PR includes padding there, and it also adds two `self.assertEqual` checks in the `DocumentTestCase.test_get_word_windows` method to test the padding.

The need for padding arose when debugging a `TestCase` that will appear in PR #38. As such, we plan to incorporate padding in the `generate_token_counter` function in `proximity.py` in that PR.