### PR TITLE
Add Link to Corpus Page

### DIFF
--- a/frontend/components/Corpora.js
+++ b/frontend/components/Corpora.js
@@ -112,12 +112,14 @@ const Corpora = () => {
             <>
                 {corporaData.map((corpus, i) => (
                     <div className="col-6 mb-3" key={i}>
-                        <div className="card">
-                            <div className="card-body">
-                                <h2 className={STYLES.title}>{corpus.title}</h2>
-                                <p>{corpus.description}</p>
+                        <a className={STYLES.corpusCard} href={`/corpus/${corpus.id}`}>
+                            <div className="card">
+                                <div className="card-body">
+                                    <h2 className={STYLES.title}>{corpus.title}</h2>
+                                    <p>{corpus.description}</p>
+                                </div>
                             </div>
-                        </div>
+                        </a>
                     </div>
                 ))}
             </>

--- a/frontend/components/Corpora.module.scss
+++ b/frontend/components/Corpora.module.scss
@@ -1,3 +1,8 @@
 .title {
   font-size: large;
 }
+
+.corpusCard {
+  color: black;
+  text-decoration: none !important;
+}


### PR DESCRIPTION
This PR makes the list of corpora on the `Corpora` page clickable, allowing users to go to the single `Corpus` page from the `Corpora` page.