### PR TITLE
Removed debugging breakpoint

### DIFF
--- a/backend/app/analysis/proximity.py
+++ b/backend/app/analysis/proximity.py
@@ -32,7 +32,6 @@ def run_analysis(corpus_id, word_window):
             genders,
             word_window
         )
-        breakpoint()
 
     return results
 


### PR DESCRIPTION
This PR removes a `breakpoint()` from debugging the code merged into `main` from PR #38.